### PR TITLE
Use raw.githubusercontent.com for AdAway

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ you have to remove previous rules and then import the new rules.
 Add the following URL as a host source.
 
 ```
-https://github.com/yous/YousList/raw/master/hosts.txt
+https://raw.githubusercontent.com/yous/YousList/master/hosts.txt
 ```
 
 ### AdGuard ([Subscribe](https://subscribe.adblockplus.org/?location=https://github.com/yous/YousList/raw/master/youslist.txt&title=YousList))


### PR DESCRIPTION
Using the "https://raw.githubusercontent.com/yous/YousList/master/hosts.txt" link
In AdAway makes the app show when update have been done instead of an unknow status 
It's just an aesthetic change for more understanding when hosts files needs to be updated