### PR TITLE
Add filters in Naver blog and DCWiki pentabox filter

### DIFF
--- a/youslist.txt
+++ b/youslist.txt
@@ -2051,8 +2051,8 @@ blog.livedoor.jp##div#ad2
 blog.livedoor.jp##iframe[src^="http://parts.blog.livedoor.jp/ad/"]
 blog.musictank.net##div#floating
 blog.naver.com##div.post_adpost
-blog.naver.com##ssp-adcontent
-blog.naver.com##ssp-adpost
+blog.naver.com###ssp-adcontent
+blog.naver.com###ssp-adpost
 blog.naver.com##span[id^="adPostInjectArea_"]
 blog.naver.com##td.adpost_con
 bloomberg.com##div.bb-ads__ad

--- a/youslist.txt
+++ b/youslist.txt
@@ -2051,6 +2051,8 @@ blog.livedoor.jp##div#ad2
 blog.livedoor.jp##iframe[src^="http://parts.blog.livedoor.jp/ad/"]
 blog.musictank.net##div#floating
 blog.naver.com##div.post_adpost
+blog.naver.com##ssp-adcontent
+blog.naver.com##ssp-adpost
 blog.naver.com##span[id^="adPostInjectArea_"]
 blog.naver.com##td.adpost_con
 bloomberg.com##div.bb-ads__ad
@@ -5366,6 +5368,7 @@ whatis.techtarget.com##div.ad-embedded
 whatis.techtarget.com##div.ad-wrapper
 whatis.techtarget.com##section.ads-by-google
 wiki.dcinside.com##iframe[src^="http://wiki.dcinside.com/main_top_realclick_banner.php"]
+wiki.dcinside.com##.pb_area
 wikia.com##div.wikia-ad
 wikihow.com##div.wh_ad_inner
 wikihow.com##div.whad


### PR DESCRIPTION
Dear yous,
I have added some filters in Naver blog and wiki.dcinside.com for blocking advertisements.
++ I fixed errors in blog.naver.com filters

Here are filters,
`blog.naver.com###ssp-adcontent`
`blog.naver.com###ssp-adpost`
`wiki.dcinside.com##.pb_area`