### PR TITLE
Reworked for cross-platform scripts 

### DIFF
--- a/bin/check_sorted.py
+++ b/bin/check_sorted.py
@@ -1,12 +1,19 @@
+# -*- coding=utf-8 -*-
 #!/usr/bin/env python
 import fileinput
 import re
+import sys
+import io
 
 """
 Check if each section separated by comment has alphabetically sorted lines.
 """
 prev_line = None
-for line in fileinput.input():
+# Make this script to run in Python 2 and Python 3
+with io.open(sys.argv[1], 'r', encoding='utf-8') as f:
+    filestream = f.readlines()
+
+for line in filestream:
     line = line.strip()
     if not line or line.startswith('!') or re.match(r'\[Adblock.*\]', line):
         prev_line = None

--- a/bin/check_sorted_hosts.py
+++ b/bin/check_sorted_hosts.py
@@ -1,11 +1,18 @@
+# -*- coding=utf-8 -*-
 #!/usr/bin/env python
 import fileinput
+import sys
+import io
 
 """
 Check if each section separated by comment has alphabetically sorted lines.
 """
 prev_line = None
-for line in fileinput.input():
+# Make this script to run in Python 2 and Python 3
+with io.open(sys.argv[1], 'r', encoding='utf-8') as f:
+    filestream = f.readlines()
+
+for line in filestream:
     line = line.strip()
     if not line or line.startswith('#'):
         prev_line = None

--- a/bin/generate_rules.py
+++ b/bin/generate_rules.py
@@ -58,7 +58,7 @@ class FilterParser:
     def _print(self, line):
         # Objects:
         # 1. Use UTF-8 as default in Python 2 and Python 3
-        # 2. Write Support cross-plarform script
+        # 2. Support cross-plarform script
         #
         # Note that sys.stdout.encoding is involved with console you use, not with Python interpreter.
         # The default encoding called code page of Windows terminal is NOT set up for utf-8.

--- a/bin/generate_rules.py
+++ b/bin/generate_rules.py
@@ -1,10 +1,12 @@
+# -*- coding=utf-8 -*-
 #!/usr/bin/env python
 import os
 import sys
 import fileinput
 import re
 import uuid
-import six
+import io
+import codecs
 
 if sys.version_info[:2] >= (2, 7):
     import json
@@ -27,7 +29,8 @@ class FilterParser:
         self.rules = []
         if basepkg:
             try:
-                f = open(basepkg)
+                # For cross-platform development, expecially for Windows Environment 
+                f = io.open(basepkg)
                 obj = json.load(f, object_pairs_hook=OrderedDict)
                 orig_pkg = obj[0]
                 self.pkg['id'] = orig_pkg['id']
@@ -42,24 +45,45 @@ class FilterParser:
             self.pkg['name'] = name
 
     def parse(self):
-        for line in fileinput.input():
-            self._parse_rule(line)
+        # For the purpose of a cross-platform expecially for Windows Environment 
+        # Windows consoles does not use 'utf-8' by default.
+        with io.open(sys.argv[1], encoding='utf-8') as f:
+            for line in f.readlines():
+                self._parse_rule(line)
         self.pkg['rules'] = self.rules
-        if six.PY2:
-            sys.stdout.write(
-                json.dumps([self.pkg], ensure_ascii=False,
-                           indent=4, separators=(',', ': '))
-                .encode('utf-8'))
+        json_string = json.dumps([self.pkg], ensure_ascii=False,
+                                indent=4, separators=(',', ': '))
+        self._print(json_string)
+
+    def _print(self, line):
+        # Objects:
+        # 1. Use UTF-8 as default in Python 2 and Python 3
+        # 2. Write Support cross-plarform script
+        #
+        # Note that sys.stdout.encoding is involved with console you use, not with Python interpreter.
+        # The default encoding called code page of Windows terminal is NOT set up for utf-8.
+        # Please refer to this page: https://stackoverflow.com/a/24104423
+        #
+        # In case this script runs in Python 3 on Linux.
+        if sys.stdout.encoding == 'UTF-8':
+            sys.stdout.write(line)
+        
+        # Otherwise,
         else:
-            sys.stdout.write(
-                json.dumps([self.pkg], ensure_ascii=False,
-                           indent=4, separators=(',', ': ')))
+            # Python 3
+            if sys.version_info.major >= 3:
+                sys.stdout.buffer.write(bytes(line.encode('utf-8')))
+            
+            # Python 2
+            else:
+                # On Windows, the output ends with CRLF.
+                if sys.platform == "win32":
+                    import msvcrt
+                    msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+                codecs.getwriter('utf-8')(sys.stdout).write(line)        
 
     def _parse_rule(self, line):
-        if six.PY2:
-            line = line.strip().decode('utf-8')
-        else:
-            line = line.strip()
+        line = line.strip()
         if not line or line.startswith('!') or re.match('\[Adblock.*\]', line):
             return
         if '##' in line:

--- a/bin/minify_pkg.py
+++ b/bin/minify_pkg.py
@@ -1,5 +1,7 @@
+# -*- coding=utf-8 -*-
 #!/usr/bin/env python
 import os
+import io
 import sys
 
 if sys.version_info[:2] >= (2, 7):
@@ -12,7 +14,7 @@ else:
 pwd = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(pwd)
 try:
-    f = open(os.path.join(root, 'Rules.1blockpkg.json'))
+    f = io.open(os.path.join(root, 'Rules.1blockpkg.json'), encoding='utf-8')
     obj = json.load(f, object_pairs_hook=OrderedDict)
     try:
         pkg_file = open(os.path.join(root, 'Rules.1blockpkg'), 'w')

--- a/bin/prettify_pkg.py
+++ b/bin/prettify_pkg.py
@@ -1,3 +1,4 @@
+# -*- coding=utf-8 -*-
 #!/usr/bin/env python
 import os
 import sys
@@ -12,7 +13,7 @@ else:
 pwd = os.path.dirname(os.path.abspath(__file__))
 root = os.path.dirname(pwd)
 try:
-    f = open(os.path.join(root, 'Rules.1blockpkg'))
+    f = io.open(os.path.join(root, 'Rules.1blockpkg'), encoding='utf-8')
     obj = json.load(f, object_pairs_hook=OrderedDict)
     try:
         json_file = open(os.path.join(root, 'Rules.1blockpkg.json'), 'w')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 # -*- encoding: utf-8 -*-
-six


### PR DESCRIPTION
I edited some source codes to run some scripts on various environments such as CentOS and even Windows. This should works, regardless of Python version and operating systems.

Check this image:
![checksum](https://user-images.githubusercontent.com/14074081/58745419-d461a380-848b-11e9-90c0-ba0f960277b4.png)

I tested on CentOS with *Intel x86 processor* and Windows 10 with *AMD x64 processor* using Python 2 and 3. All files have same checksums, which means they have same contents including *EOL character*. 
