### PR TITLE
[Optional] Remove problematic rule for pbs.twimg.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -395,7 +395,6 @@
 0.0.0.0 dspserver.adpnut.com
 0.0.0.0 ebdr3.com
 0.0.0.0 ecdn.firstimpression.io
-0.0.0.0 edgecastcdn.net
 0.0.0.0 engine.adzerk.net
 0.0.0.0 eto.co.kr
 0.0.0.0 ex.mdtoday.co.kr


### PR DESCRIPTION
By blocking `edgecastcdn.net`, various types of services stopped working.

Followed by DNS chain in answer section generated by `dig`:
```
dig pbs.twimg.com

; <<>> DiG 9.10.6 <<>> pbs.twimg.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57979
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;pbs.twimg.com.            IN    A

;; ANSWER SECTION:
pbs.twimg.com.        300    IN    CNAME    cs196.wac.edgecastcdn.net.
cs196.wac.edgecastcdn.net. 300    IN    CNAME    cs2-wac.apr-8315.edgecastdns.net.
cs2-wac.apr-8315.edgecastdns.net. 300 IN CNAME    cs2-wac-as.8315.ecdns.net.
cs2-wac-as.8315.ecdns.net. 300    IN    CNAME    cs505.wac.edgecastcdn.net.
cs505.wac.edgecastcdn.net. 300    IN    A    192.229.237.101

;; Query time: 3 msec
;; SERVER: 1.1.1.2#53(1.1.1.2)
;; WHEN: Tue Apr 26 11:21:49 KST 2022
;; MSG SIZE  rcvd: 196
```

From the line `cs2-wac-as.8315.ecdns.net. 300    IN    CNAME    cs505.wac.edgecastcdn.net.`, by filtering `edgecastcdn.net` causes invalid blocking to `pbs.twimg.com`.

## Question here

If you intended to support AdGuard DNS protection from `hosts.txt`, please accept this PR, otherwise if the file will follow the normal DNS host file term and won't expect to block the subdomains of `edgecastcdn.net`, you can just reject this PR.